### PR TITLE
Fix animation speed parameter mismatch in animation-element.js

### DIFF
--- a/animation-element.js
+++ b/animation-element.js
@@ -5,7 +5,7 @@ export default class AnimationElement extends HTMLElement {
     static #intervals = {};
     /** @type {Number} Number of seconds for each animation */
     get animationSpeed(){
-        return parseFloat( this.getAttribute('animation-duration') )*1000 || 500
+        return parseFloat( this.getAttribute('animation-speed') )*1000 || 500
     }
     /** @type {Boolean} Determines whether the animation should be ran */
     isAnimationEnabled;


### PR DESCRIPTION
This PR resolves issue #1 by changing the attribute name from 'animation-duration' to 'animation-speed' in the animation-element.js file to match the parameter name used in index.html.