### PR TITLE
Fix animation speed parameter mismatch between HTML and JavaScript

### DIFF
--- a/animation-element.js
+++ b/animation-element.js
@@ -5,7 +5,7 @@ export default class AnimationElement extends HTMLElement {
     static #intervals = {};
     /** @type {Number} Number of seconds for each animation */
     get animationSpeed(){
-        return parseFloat( this.getAttribute('animation-duration') )*1000 || 500
+        return parseFloat( this.getAttribute('animation-speed') )*1000 || 500
     }
     /** @type {Boolean} Determines whether the animation should be ran */
     isAnimationEnabled;


### PR DESCRIPTION
This PR fixes the issue where animation speed control wasn't working due to a parameter naming inconsistency. The HTML file was using 'animation-speed' while the JavaScript file was expecting 'animation-duration'. This change standardizes the parameter name to ensure the speed control functionality works properly.

Fixes #1