### PR TITLE
Fix: Change animation-duration to animation-speed attribute in AnimationElement

### DIFF
--- a/animation-element.js
+++ b/animation-element.js
@@ -5,7 +5,7 @@ export default class AnimationElement extends HTMLElement {
     static #intervals = {};
     /** @type {Number} Number of seconds for each animation */
     get animationSpeed(){
-        return parseFloat( this.getAttribute('animation-duration') )*1000 || 500
+        return parseFloat( this.getAttribute('animation-speed') )*1000 || 500
     }
     /** @type {Boolean} Determines whether the animation should be ran */
     isAnimationEnabled;


### PR DESCRIPTION
## Problem
There was an inconsistency in the codebase where the base `AnimationElement` class was looking for the `animation-duration` attribute, while all HTML files and documentation examples were using `animation-speed`. This caused animation speed configuration to not work as expected.

## Solution
Changed line 8 in `animation-element.js` from:
```javascript
return parseFloat( this.getAttribute('animation-duration') )*1000 || 500
```
to:
```javascript
return parseFloat( this.getAttribute('animation-speed') )*1000 || 500
```

## Impact
- Ensures consistent attribute naming across the entire codebase
- Fixes animation speed configuration for all web components that extend `AnimationElement`
- Aligns implementation with documentation and examples

## Files Changed
- `animation-element.js`: Updated attribute name in animationSpeed getter method

## Testing
The fix ensures that animation speed values specified in HTML using the `animation-speed` attribute will now be properly recognized and applied by the JavaScript implementation.